### PR TITLE
removed max line length for template files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,8 @@ max_line_length = off
 [*.js]
 max_line_length = 120
 
-[*.{html, phtml}]
-max_line_length = 120
+[*.{html, phtml, twig}]
+max_line_length = off
 
 [*.{md, markdown, txt}]
 max_line_length = off


### PR DESCRIPTION
Remove the default 120 character line limitation for template files (`html`, `phtml` and `twig`).